### PR TITLE
dbs to Dbs

### DIFF
--- a/config_param.go
+++ b/config_param.go
@@ -18,7 +18,7 @@ func (p *Parameters) Store(sess db.Session) db.Store {
 	return sess.Collection("parameters")
 }
 
-func (dd *dbs) fromConfig(config *DbInfo, key string) (out string, err error) {
+func (dd *Dbs) fromConfig(config *DbInfo, key string) (out string, err error) {
 	var sess db.Session
 	out = ""
 	defer func() {

--- a/types.go
+++ b/types.go
@@ -17,7 +17,7 @@ const modError = "dbscan"
 // 	DbPath() string
 // }
 
-type dbs struct {
+type Dbs struct {
 	// Apper
 	path  string
 	infos ListDbInfoForScan
@@ -26,8 +26,8 @@ type dbs struct {
 // dbPath путь сканирования БД A3 и 4Z
 // listInfo описатели для всех БД
 // пустой путь перезаписывается на текущий "."
-func New(listInfo ListDbInfoForScan, dbPath string) (d *dbs, err error) {
-	d = &dbs{
+func New(listInfo ListDbInfoForScan, dbPath string) (d *Dbs, err error) {
+	d = &Dbs{
 		// Apper: app,
 		infos: make(ListDbInfoForScan),
 	}
@@ -126,7 +126,7 @@ func New(listInfo ListDbInfoForScan, dbPath string) (d *dbs, err error) {
 	return d, nil
 }
 
-func (d *dbs) Info(t DbInfoType) *DbInfo {
+func (d *Dbs) Info(t DbInfoType) *DbInfo {
 	if dbi, ok := d.infos[t]; ok {
 		return dbi
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed and exported the core database type from “dbs” to “Dbs” to clarify the public API.
  - Updated the constructor to return “*Dbs” and aligned method receivers to the new type.
  - No functional or behavioral changes; existing logic remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->